### PR TITLE
Use self-hosted runner for test

### DIFF
--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -38,7 +38,7 @@ jobs:
           security list-keychain -d user -s $KEYCHAIN_PATH
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         env:
@@ -65,7 +65,7 @@ jobs:
           xcrun stapler staple *.dmg
 
       - name: Upload dmg
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Disk image
           path: build/Release/*.dmg

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: macos-latest self-hosted
+    runs-on: [macOS, self-hosted]
 
     steps:
       - name: Xcode version

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: macos-latest self-hosted
 
     steps:
       - name: Xcode version


### PR DESCRIPTION
This PR updates the Github actions to a working set, and successfully tests building the project on a self-hosted runner.