### PR TITLE
Unlock keychain before use in "notarize dmg"

### DIFF
--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -57,11 +57,11 @@ jobs:
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           cd build/Release/
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $RUNNER_TEMP/build.keychain-db
           for item in *.app *.dmg ; do
             codesign --verify --deep --verbose "$item" || echo "codesign: NOK"
             spctl --assess --type execute --context context:primary-signature -vvv "$item" || echo "spctl: NOK"
           done
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $RUNNER_TEMP/build.keychain-db
           xcrun notarytool store-credentials AC_PASSWORD --apple-id "$AC_USER" --team-id "$DEVELOPMENT_TEAM" --password "$AC_PASSWORD"
           xcrun notarytool submit *.dmg --keychain-profile AC_PASSWORD --wait
           xcrun stapler staple *.dmg

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -69,9 +69,9 @@ jobs:
           security list-keychain -d user -s $KEYCHAIN_PATH
 
           echo before notary store
-          xcrun notarytool store-credentials AC_PASSWORD --apple-id "$AC_USER" --team-id "$DEVELOPMENT_TEAM" --password "$AC_PASSWORD"
+          xcrun notarytool store-credentials AC_PASSWORD --apple-id "$AC_USER" --team-id "$DEVELOPMENT_TEAM" --password "$AC_PASSWORD" --keychain $KEYCHAIN_PATH
           echo before notary submit
-          xcrun notarytool submit *.dmg --keychain-profile AC_PASSWORD --wait
+          xcrun notarytool submit *.dmg --keychain-profile AC_PASSWORD --keychain $KEYCHAIN_PATH --wait
           echo before staple
           xcrun stapler staple *.dmg
 

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -63,11 +63,8 @@ jobs:
           done
 
           KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain-db
-          #security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          #security list-keychain -d user -s $KEYCHAIN_PATH
-
-          xcrun notarytool store-credentials AC_PASSWORD --apple-id "$AC_USER" --team-id "$DEVELOPMENT_TEAM" --password "$AC_PASSWORD" --keychain $KEYCHAIN_PATH
-          xcrun notarytool submit *.dmg --keychain-profile AC_PASSWORD --keychain $KEYCHAIN_PATH --wait
+          xcrun notarytool store-credentials AC_PASSWORD --apple-id "$AC_USER" --team-id "$DEVELOPMENT_TEAM" --password "$AC_PASSWORD" --keychain "$KEYCHAIN_PATH"
+          xcrun notarytool submit *.dmg --keychain-profile AC_PASSWORD --keychain "$KEYCHAIN_PATH" --wait
           xcrun stapler staple *.dmg
 
       - name: Upload dmg

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -58,9 +58,10 @@ jobs:
         run: |
           # create variables
           KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain-db
-          ls -al "$KEYCHAIN_PATH"
-          security list-keychains -s $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychains -s "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          env
 
           cd build/Release/
           for item in *.app *.dmg ; do

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -56,20 +56,23 @@ jobs:
           DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
-          # create variables
-          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain-db
-          security list-keychains -s "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          env
-
           cd build/Release/
           for item in *.app *.dmg ; do
             codesign --verify --deep --verbose "$item" || echo "codesign: NOK"
             spctl --assess --type execute --context context:primary-signature -vvv "$item" || echo "spctl: NOK"
           done
+
+          # create variables
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain-db
+
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          echo before notary store
           xcrun notarytool store-credentials AC_PASSWORD --apple-id "$AC_USER" --team-id "$DEVELOPMENT_TEAM" --password "$AC_PASSWORD"
+          echo before notary submit
           xcrun notarytool submit *.dmg --keychain-profile AC_PASSWORD --wait
+          echo before staple
           xcrun stapler staple *.dmg
 
       - name: Upload dmg

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -60,6 +60,7 @@ jobs:
             codesign --verify --deep --verbose "$item" || echo "codesign: NOK"
             spctl --assess --type execute --context context:primary-signature -vvv "$item" || echo "spctl: NOK"
           done
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           xcrun notarytool store-credentials AC_PASSWORD --apple-id "$AC_USER" --team-id "$DEVELOPMENT_TEAM" --password "$AC_PASSWORD"
           xcrun notarytool submit *.dmg --keychain-profile AC_PASSWORD --wait
           xcrun stapler staple *.dmg

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -54,6 +54,7 @@ jobs:
           AC_USER: ${{ secrets.AC_USER }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           cd build/Release/
           for item in *.app *.dmg ; do

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -62,17 +62,12 @@ jobs:
             spctl --assess --type execute --context context:primary-signature -vvv "$item" || echo "spctl: NOK"
           done
 
-          # create variables
           KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain-db
+          #security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          #security list-keychain -d user -s $KEYCHAIN_PATH
 
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-
-          echo before notary store
           xcrun notarytool store-credentials AC_PASSWORD --apple-id "$AC_USER" --team-id "$DEVELOPMENT_TEAM" --password "$AC_PASSWORD" --keychain $KEYCHAIN_PATH
-          echo before notary submit
           xcrun notarytool submit *.dmg --keychain-profile AC_PASSWORD --keychain $KEYCHAIN_PATH --wait
-          echo before staple
           xcrun stapler staple *.dmg
 
       - name: Upload dmg

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -61,7 +61,7 @@ jobs:
             codesign --verify --deep --verbose "$item" || echo "codesign: NOK"
             spctl --assess --type execute --context context:primary-signature -vvv "$item" || echo "spctl: NOK"
           done
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $RUNNER_TEMP/build.keychain-db
           xcrun notarytool store-credentials AC_PASSWORD --apple-id "$AC_USER" --team-id "$DEVELOPMENT_TEAM" --password "$AC_PASSWORD"
           xcrun notarytool submit *.dmg --keychain-profile AC_PASSWORD --wait
           xcrun stapler staple *.dmg

--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -56,8 +56,13 @@ jobs:
           DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
+          # create variables
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain-db
+          ls -al "$KEYCHAIN_PATH"
+          security list-keychains -s $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
           cd build/Release/
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $RUNNER_TEMP/build.keychain-db
           for item in *.app *.dmg ; do
             codesign --verify --deep --verbose "$item" || echo "codesign: NOK"
             spctl --assess --type execute --context context:primary-signature -vvv "$item" || echo "spctl: NOK"


### PR DESCRIPTION
Adding an explicit step to unlock the keychain before use, should help against the failing automated builds I currently see