### PR TITLE
Add workflow_dispatch trigger to build workflow

### DIFF
--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -1,6 +1,7 @@
 name: Build and Analyze
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
   pull_request:


### PR DESCRIPTION
This PR is going to add a workflow dispatch clause to the GitHub action. 
This allows triggering the build action directly from GitHub without any source modifications.